### PR TITLE
Toevoeging van .gitignore voor het verwijderen van "Zone.Identifier" bestanden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore the following files
+.playbooks/delete.ymlZone.Identifier
+.playbooks/install_monitoring.ymlZone.Identifier
+.playbooks/setup.ymlZone.Identifier
+.playbooks/setup_software.ymlZone.Identifier

--- a/playbooks/delete.ymlZone.Identifier
+++ b/playbooks/delete.ymlZone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/playbooks/setup.ymlZone.Identifier
+++ b/playbooks/setup.ymlZone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/playbooks/setup_software.ymlZone.Identifier
+++ b/playbooks/setup_software.ymlZone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3


### PR DESCRIPTION
Add: .gitignore
Remove: playbooks/delete.yml%EF%80%BAZone.Identifier
Remove: playbooks/setup.yml%EF%80%BAZone.Identifier
Remove: playbooks/setup_software.yml%EF%80%BAZone.Identifier